### PR TITLE
ci: add test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run Tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install test tooling
+        run: python -m pip install pytest
+
+      - name: Compile Python sources
+        run: python -m compileall medea main.py utils.py
+
+      - name: Run unit tests
+        run: |
+          if [ -d tests ]; then
+            python -m pytest tests -q
+          else
+            echo "No tests directory found; skipping pytest discovery."
+          fi


### PR DESCRIPTION
## Summary
- add a lightweight GitHub Actions workflow for Medea pull requests and pushes to main
- compile the Python sources on Python 3.10 and 3.11
- run pytest when a tests directory is present

## Validation
- python -m compileall medea main.py utils.py
- git diff --check
