### PR TITLE
docs: fix package repository links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,9 +138,9 @@ jupyter = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/mims-harvard/Medea-1.0"
-Repository = "https://github.com/mims-harvard/Medea-1.0"
-Documentation = "https://github.com/mims-harvard/Medea-1.0#readme"
+Homepage = "https://github.com/mims-harvard/Medea"
+Repository = "https://github.com/mims-harvard/Medea"
+Documentation = "https://github.com/mims-harvard/Medea#readme"
 
 [project.scripts]
 medea-eval = "medea.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Multi-Agent Research Planning System for Single-Cell Analysis and Therapeutic Discovery",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mims-harvard/Medea-1.0",
+    url="https://github.com/mims-harvard/Medea",
     packages=find_packages(exclude=["evaluation", "evaluation.*", "results", "results.*", "plots", "plots.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- update package metadata links from the stale Medea-1.0 URL to the current mims-harvard/Medea repository
- keep setup.py and pyproject.toml consistent

## Validation
- python -m compileall medea main.py utils.py
- python -c "import pathlib; text=pathlib.Path('pyproject.toml').read_text(encoding='utf-8'); assert 'Medea-1.0' not in text; assert 'https://github.com/mims-harvard/Medea' in text; print('metadata links ok')"
- git diff --check
