### PR TITLE
fix: add medea-eval entrypoint module

### DIFF
--- a/medea/cli.py
+++ b/medea/cli.py
@@ -1,0 +1,15 @@
+"""Console entry points for Medea."""
+
+from pathlib import Path
+import runpy
+
+
+def main():
+    """Run the repository evaluation CLI used by ``python main.py``."""
+    entrypoint = Path(__file__).resolve().parents[1] / "main.py"
+    if not entrypoint.exists():
+        raise FileNotFoundError(
+            "Could not find main.py next to the Medea package. "
+            "Run `python main.py` from a source checkout instead."
+        )
+    runpy.run_path(str(entrypoint), run_name="__main__")


### PR DESCRIPTION
## Summary
- add the missing medea.cli module referenced by the medea-eval console script
- delegate to the existing main.py evaluation CLI used in the README
- return a clear error if the source checkout entrypoint is unavailable

## Validation
- python -m compileall medea main.py utils.py
- python -c "import importlib.util; spec=importlib.util.spec_from_file_location('medea_cli','medea/cli.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); assert callable(mod.main); print('cli wrapper ok')"
- git diff --check

Note: Direct `from medea.cli import main` requires the full Medea runtime dependencies because medea/__init__.py imports core modules at package import time.
