### PR TITLE
docs: add credential-light smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ uv pip install -e .
 uv pip install openai==1.82.1  # Ensure correct OpenAI version
 ```
 
+### Credential-light smoke test
+
+Before downloading MedeaDB or configuring model-provider credentials, verify that
+the package imports correctly in the active environment:
+
+```bash
+python - <<'PY'
+import medea
+
+print("Medea import OK")
+print(medea.__file__)
+PY
+```
+
+This check is intentionally limited to package import health. Full agent runs
+still require `MEDEADB_PATH` and at least one configured LLM provider key.
+
 ### Download MedeaDB
 
 Download required datasets from Hugging Face:


### PR DESCRIPTION
Summary
- add a small README smoke-test step for verifying Medea imports before downloading MedeaDB or configuring provider credentials
- clarify that full agent runs still require MEDEADB_PATH and an LLM provider key

Validation
- git diff --check
- python -m compileall -q medea setup.py